### PR TITLE
Corrige escopo de consulta dos algoritmos

### DIFF
--- a/app/jobs/correlacao_job.rb
+++ b/app/jobs/correlacao_job.rb
@@ -23,6 +23,7 @@ class CorrelacaoJob < ApplicationJob
 
       part_ids = Part.in(member: members).pluck(:id)
       comments = Comment.in(author_id: author_ids, part_id: part_ids)
+      datasource = comments.last.datasource
 
       next if comments.empty?
 
@@ -30,7 +31,7 @@ class CorrelacaoJob < ApplicationJob
 
       comments.each do |comment|
         part = comment.part
-        parts = Part.where(member: part.member)
+        parts = Part.where(member: part.member, datasource: datasource)
         part = parts.sort{|a,b| a.name.size <=> b.name.size}.first
         part_id = part.id.to_s
 

--- a/app/jobs/sentimento_job.rb
+++ b/app/jobs/sentimento_job.rb
@@ -23,8 +23,9 @@ class SentimentoJob < ApplicationJob
       comment_id, value = line.split(' ')
 
       comment = Comment.find(comment_id)
+      datasource = comment.datasource
       part = comment.part
-      parts = Part.where(member: comment.part.member)
+      parts = Part.where(member: comment.part.member, datasource: datasource)
       part = parts.sort{|a,b| a.name.size <=> b.name.size}.first
       part_id = part.id.to_s
 


### PR DESCRIPTION
Nos algoritmos de correlação e análise de sentimentos nós estávamos fazendo consultas na forma Part.where(membro: foo). Só que isso acaba pegando parts de outros datasources e gerando dados inválidos e/ou crashando a consulta.

Neste commit eu coloquei um escopo nos lugares necessários.